### PR TITLE
Adding a Limitations section (Addresses and Closes #34)

### DIFF
--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -677,6 +677,19 @@ Trace complete.
       </t>
     </section>
 
+    <section title="Limitations">
+      <t>
+        Section 7 of <xref target="RFC4884" /> defines the ICMP Extension Structure. 
+        As per RFC 4884, the Extension Structure contains exactly one Extension
+        Header followed by one or more objects.  When applied to the ICMP Extended 
+        Echo Request message, the ICMP Extension Structure MUST contain exactly 
+        one instance of the Interface Identification Object (Section 2.1 of 
+        <xref target="RFC8335" />). So, due to the limitation of not being able to
+        append more than one extension obect to an Extended Echo, the extension 
+        objects defined herein cannot be appended to an Extended Echo Message.
+      </t>
+    </section>
+
     <section title="IANA Considerations">
       <t>
         IANA is requested to assign the following object Class-num in the ICMP 
@@ -786,7 +799,7 @@ Trace complete.
       &RFC.4884;
       &RFC.8174;
       &RFC.8335;
-            
+
     </references>
     
     <references title="Informative References">

--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -689,7 +689,7 @@ Trace complete.
         Echo Request message, the ICMP Extension Structure MUST contain exactly 
         one instance of the Interface Identification Object (Section 2.1 of 
         <xref target="RFC8335" />). So, due to the limitation of not being able to
-        append more than one extension obect to an Extended Echo, the extension 
+        append more than one extension object to an Extended Echo, the extension 
         objects defined herein cannot be appended to an Extended Echo Message.
       </t>
     </section>


### PR DESCRIPTION
Added a limitations section to add the limitation of not being able to append environmental information extensions to an Extended Echo Message, as stated in [RFC 8335](https://datatracker.ietf.org/doc/html/rfc8335#section-2) and https://datatracker.ietf.org/doc/draft-fenner-intarea-probe-clarification/

Closes #34 