### PR TITLE
Defining a wide 64-bit Sub-Object (Address and Closes #35)

### DIFF
--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -425,7 +425,7 @@
             </figure>
             A Class-Num of TBA and a C-Type of 3 are specified.  
             <vspace blankLines="1" />
-            The Length is 16 if the object contains this payload.
+            The Length is 12 if the object contains this payload.
             A Length value of 4 indicates that it is unavailable.
             <vspace blankLines="1" />
             The returned value is the node-level present throughput, 

--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -647,7 +647,6 @@
       </t>
       
       <t>
-        Now that we have put forward these two format options, here's how a device MUST
         choose amongst the available format options. It is recommended that the device
         chooses a format based on the size of the value that it wants to append. For 
         example, If the component/node throughput is more less than 4Gbps, the device 

--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -636,7 +636,7 @@
         mind. With the industry shifting towards high density ports/components and 
         nodes, organizations now have components/interfaces/line cards with 10/40/100Gbps 
         or even 400Gbps throughput and nodes with a combined throughput of greater than
-        10Tbps. Now this cannot be represented in a field wihich is only 32-bit long. 
+        10Tbps. This cannot be represented in a field which is only 32-bit long. 
         Because a 32-bit field can only represent a max throughput of 4Gbps (2 ^ 32 BPS).
         So, to address this, we chose to define another format, a wider, 64-bit Sub-Object
         format.

--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -661,7 +661,7 @@
         and another has a throughput of 10Gbps and if the device would like to append
         the throughput of both the components, as discussed above, the device will be
         able to choose a Sub-object with C-Type=6 for the line card with 2Gbps throughput 
-        and also will be able to choose a Sub-Object with C-Type=7 for the line card with 
+        and will also be able to choose a Sub-Object with C-Type=7 for the line card with 
         10Gbps throughput.
       </t>
     </section>

--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -647,7 +647,7 @@
       </t>
       
       <t>
-        choose amongst the available format options. It is recommended that the device
+        It is recommended that the device
         chooses a format based on the size of the value that it wants to append. For 
         example, If the component/node throughput is more less than 4Gbps, the device 
         MUST append the "short" 32-bit Sub-Object. And when the component/node throughput

--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -650,7 +650,7 @@
         It is recommended that the device
         chooses a format based on the size of the value that it wants to append. For 
         example, If the component/node throughput is more less than 4Gbps, the device 
-        MUST append the "short" 32-bit Sub-Object. And when the component/node throughput
+        would append the "short" 32-bit Sub-Object. When the component/node throughput
         exceeds 4Gbps, the device would append the "wide" 64-bit Sub-Object. This will 
         ensure the optimal use of the formats and make the extension object space efficient.
       </t>

--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -657,7 +657,7 @@
 
       <t>
         Both of these formats are interoperable and can co-exist in the same Extension 
-        Object. i.e. For if a device has two line cards, one has a throughput of 2Gbps 
+        Object. i.e. For example, if a device has two line cards, one with a throughput of 2Gbps 
         and another has a throughput of 10Gbps and if the device would like to append
         the throughput of both the components, as discussed above, the device will be
         able to choose a Sub-object with C-Type=6 for the line card with 2Gbps throughput 

--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -384,10 +384,10 @@
           </t>
 
           <t>
-            Node Throughput Sub-Object
+            Node Throughput Short Sub-Object
             
             <figure anchor="ctype-2" 
-                    title="Node Throughput Sub-Object">
+                    title="Node Throughput Short Sub-Object">
               <artwork xml:space="preserve" >
                      1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -435,7 +435,7 @@
             between power and traffic load.
             <vspace blankLines="1" />
             There's an in-depth discussion on why there are two formats,
-            a 32-bit regular and a 64-bit wide, and when will one be 
+            a 32-bit "short" and a 64-bit "wide", and when will one be 
             chosen over the other, in Section <xref target="subobject-formats" />.
           </t>
 
@@ -512,9 +512,9 @@
           </t>
 
           <t>
-            Component-level Throughput Sub-Object
+            Component-level Throughput Short Sub-Object
             <figure anchor="ctype-6" 
-                    title="Component-level Throughput Element">
+                    title="Component-level Throughput Short Element">
               <artwork xml:space="preserve" >
                      1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -581,7 +581,7 @@
             and traffic load.
             <vspace blankLines="1" />
             There's an in-depth discussion on why there are two formats,
-            a 32-bit regular and a 64-bit wide, and when will one be 
+            a 32-bit "short" and a 64-bit "wide", and when will one be 
             chosen over the other, in <xref target="subobject-formats" />.
           </t>
         </list>
@@ -626,7 +626,7 @@
 
     <section anchor="subobject-formats" title="Sub-Object Formats">
       <t>
-        As discussed in <xref target="ctype" />, apart from the 32-bit "regular" 
+        As discussed in <xref target="ctype" />, apart from the 32-bit "short" 
         sub-object, we have also defined a 64-bit "wide" format for Node and 
         Component throughput Sub-Objects.
       </t>
@@ -647,7 +647,7 @@
         choose amongst the available format options. It is recommended that the device
         chooses a format based on the size of the value that it wants to append. For 
         example, If the component/node throughput is more less than 4Gbps, the device 
-        MUST append the regular 32-bit Sub-Object. And when the component/node throughput
+        MUST append the "short" 32-bit Sub-Object. And when the component/node throughput
         exceeds 4Gbps, the device MUST append the "wide" 64-bit Sub-Object. This will 
         ensure the optimal use of the formats and make the extension object space efficient.
       </t>

--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -586,7 +586,7 @@
             <vspace blankLines="1" />
             A discussion on why there are two formats,
             a 32-bit "short" and a 64-bit "wide", and when will one be 
-            chosen over the other, in <xref target="subobject-formats" />.
+            chosen over the other, can be found in <xref target="subobject-formats" />.
           </t>
         </list>
 

--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -584,7 +584,7 @@
             of the ICMP message to determine a relationship between power 
             and traffic load.
             <vspace blankLines="1" />
-            There's an in-depth discussion on why there are two formats,
+            A discussion on why there are two formats,
             a 32-bit "short" and a 64-bit "wide", and when will one be 
             chosen over the other, in <xref target="subobject-formats" />.
           </t>

--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -409,8 +409,39 @@
           </t>
 
           <t>
+            Node Throughput Wide Sub-Object
+            
+            <figure anchor="ctype-3" 
+                    title="Node Throughput Wide Sub-Object">
+              <artwork xml:space="preserve" >
+                     1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|             Throughput (32-bit unsigned word 1)               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|             Throughput (32-bit unsigned word 2)               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+              </artwork>
+            </figure>
+            A Class-Num of TBA and a C-Type of 3 are specified.  
+            <vspace blankLines="1" />
+            The Length is 16 if the object contains this payload.
+            A Length value of 4 indicates that it is unavailable.
+            <vspace blankLines="1" />
+            The returned value is the node-level present throughput, 
+            which is a magnitude that may be directly displayed, and 
+            is expressed in bits-per-second (BPS). This allows the 
+            recipient of the ICMP message to determine a relationship 
+            between power and traffic load.
+            <vspace blankLines="1" />
+            There's an in-depth discussion on why there are two formats,
+            a 32-bit regular and a 64-bit wide, and when will one be 
+            chosen over the other, in Section <xref target="subobject-formats" />.
+          </t>
+
+          <t>
             Ecolabels and Environmentally Relevant Certification (EERC) Sub-Object
-              <figure anchor="ctype-3" 
+              <figure anchor="ctype-4" 
                       title="EERC Sub-Object">
                 <artwork xml:space="preserve" >
                      1                   2                   3
@@ -421,7 +452,7 @@
                 </artwork>
               </figure>
 
-            A Class-Num of TBA and a C-Type of 3 are specified.  
+            A Class-Num of TBA and a C-Type of 4 are specified.  
             <vspace blankLines="1" />
             The Length is 8 if the object contains this payload.
             A Length value of 4 indicates that it is unavailable.
@@ -442,7 +473,7 @@
 
           <t>
             Component-level Power Draw Sub-Object
-            <figure anchor="ctype-4" 
+            <figure anchor="ctype-5" 
                     title="Component-level Power Draw Element">
               <artwork xml:space="preserve" >
                      1                   2                   3
@@ -462,7 +493,7 @@
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
               </artwork>
             </figure>
-            A Class-Num of TBA and a C-Type of 4 are specified.  
+            A Class-Num of TBA and a C-Type of 5 are specified.  
             <vspace blankLines="1" />
             The Length is 4 plus 20 times the number of 
             elements included. A Length value of 4 indicates that
@@ -482,7 +513,7 @@
 
           <t>
             Component-level Throughput Sub-Object
-            <figure anchor="ctype-5" 
+            <figure anchor="ctype-6" 
                     title="Component-level Throughput Element">
               <artwork xml:space="preserve" >
                      1                   2                   3
@@ -500,7 +531,7 @@
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
               </artwork>
             </figure>
-            A Class-Num of TBA and a C-Type of 5 are specified.  
+            A Class-Num of TBA and a C-Type of 6 are specified.  
             <vspace blankLines="1" />
             The Length is 4 plus 20 times the number of 
             elements included. A Length value of 4 indicates that
@@ -512,7 +543,47 @@
             throughput of said component in bits-per-second (BPS).
             This allows the recipient of the ICMP message to determine a
             relationship between power and traffic load.
-          </t>          
+          </t>
+
+          <t>
+            Component-level Throughput Wide Sub-Object
+            <figure anchor="ctype-7" 
+                    title="Component-level Throughput Wide Sub-Object">
+              <artwork xml:space="preserve" >
+                     1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                      UUID 32-bit Word 1                       |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                      UUID 32-bit Word 2                       |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                      UUID 32-bit Word 3                       |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                      UUID 32-bit Word 4                       |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|             Component Throughput (32-bit word 1)              |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|             Component Throughput (32-bit word 2)              |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+              </artwork>
+            </figure>
+            A Class-Num of TBA and a C-Type of 7 are specified.  
+            <vspace blankLines="1" />
+            The Length is 4 plus 24 times the number of 
+            elements included. A Length value of 4 indicates that
+            this object is unavailable.
+            <vspace blankLines="1" />
+            The returned value is one or more instances of component-level 
+            throughput. Each instance is a set comprised by a UUID uniquely 
+            identifying the component, and the actual throughput of said 
+            component in bits-per-second (BPS). This allows the recipient 
+            of the ICMP message to determine a relationship between power 
+            and traffic load.
+            <vspace blankLines="1" />
+            There's an in-depth discussion on why there are two formats,
+            a 32-bit regular and a 64-bit wide, and when will one be 
+            chosen over the other, in <xref target="subobject-formats" />.
+          </t>
         </list>
 
 <!--
@@ -551,6 +622,45 @@
 -->
 
       </section>
+    </section>
+
+    <section anchor="subobject-formats" title="Sub-Object Formats">
+      <t>
+        As discussed in <xref target="ctype" />, apart from the 32-bit "regular" 
+        sub-object, we have also defined a 64-bit "wide" format for Node and 
+        Component throughput Sub-Objects.
+      </t>
+      
+      <t>
+        The 64-bit format was defined keeping the present trends of the industry in
+        mind. With the industry shifting towards high density ports/components and 
+        nodes, organizations now have components/interfaces/line cards with 10/40/100Gbps 
+        or even 400Gbps throughput and nodes with a combined throughput of greater than
+        10Tbps. Now this cannot be represented in a field wihich is only 32-bit long. 
+        Because a 32-bit field can only represent a max throughput of 4Gbps (2 ^ 32 BPS).
+        So, to address this, we chose to define another format, a wider, 64-bit Sub-Object
+        format.
+      </t>
+      
+      <t>
+        Now that we have put forward these two format options, here's how a device MUST
+        choose amongst the available format options. It is recommended that the device
+        chooses a format based on the size of the value that it wants to append. For 
+        example, If the component/node throughput is more less than 4Gbps, the device 
+        MUST append the regular 32-bit Sub-Object. And when the component/node throughput
+        exceeds 4Gbps, the device MUST append the "wide" 64-bit Sub-Object. This will 
+        ensure the optimal use of the formats and make the extension object space efficient.
+      </t>
+
+      <t>
+        Both of these formats are interoperable and can co-exist in the same Extension 
+        Object. i.e. For if a device has two line cards, one has a throughput of 2Gbps 
+        and another has a throughput of 10Gbps and if the device would like to append
+        the throughput of both the components, as discussed above, the device will be
+        able to choose a Sub-object with C-Type=6 for the line card with 2Gbps throughput 
+        and also will be able to choose a Sub-Object with C-Type=7 for the line card with 
+        10Gbps throughput.
+      </t>
     </section>
 
     <section title="Sample Use Case">
@@ -712,15 +822,21 @@ Trace complete.
           <c>Node Throughput</c>
           <c>This document</c>
           <c>3</c>
-          <c>Ecolabels and Environmentally Relevant Certification (EERC)</c>
+          <c>Node Throughput Wide</c>
           <c>This document</c>
           <c>4</c>
-          <c>Component-level Power Draw</c>
+          <c>Ecolabels and Environmentally Relevant Certification (EERC)</c>
           <c>This document</c>
           <c>5</c>
+          <c>Component-level Power Draw</c>
+          <c>This document</c>
+          <c>6</c>
           <c>Component-level Throughput</c>
           <c>This document</c>
-          <c>6-246</c>
+          <c>7</c>
+          <c>Component-level Throughput Wide</c>
+          <c>This document</c>
+          <c>8-246</c>
           <c>Unassigned</c>
           <c>&nbsp;</c>
           <c>247-255</c>

--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -651,7 +651,7 @@
         chooses a format based on the size of the value that it wants to append. For 
         example, If the component/node throughput is more less than 4Gbps, the device 
         MUST append the "short" 32-bit Sub-Object. And when the component/node throughput
-        exceeds 4Gbps, the device MUST append the "wide" 64-bit Sub-Object. This will 
+        exceeds 4Gbps, the device would append the "wide" 64-bit Sub-Object. This will 
         ensure the optimal use of the formats and make the extension object space efficient.
       </t>
 

--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -638,7 +638,7 @@
         or even 400Gbps throughput and nodes with a combined throughput of greater than
         10Tbps. This cannot be represented in a field which is only 32-bit long. 
         Because a 32-bit field can only represent a max throughput of 4Gbps (2 ^ 32 BPS).
-        So, to address this, we chose to define another format, a wider, 64-bit Sub-Object
+        To address this, we define another format, a wider, 64-bit Sub-Object
         format.
       </t>
       

--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -658,7 +658,7 @@
       <t>
         Both of these formats are interoperable and can co-exist in the same Extension 
         Object. i.e. For example, if a device has two line cards, one with a throughput of 2Gbps 
-        and another has a throughput of 10Gbps and if the device would like to append
+        and another which has a throughput of 10Gbps, and if the device would like to append
         the throughput of both the components, as discussed above, the device will be
         able to choose a Sub-object with C-Type=6 for the line card with 2Gbps throughput 
         and will also be able to choose a Sub-Object with C-Type=7 for the line card with 

--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -831,7 +831,7 @@ Trace complete.
           <c>Component-level Power Draw</c>
           <c>This document</c>
           <c>6</c>
-          <c>Component-level Throughput</c>
+          <c>Component-level Throughput Short</c>
           <c>This document</c>
           <c>7</c>
           <c>Component-level Throughput Wide</c>

--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -641,7 +641,7 @@
         nodes, organizations now have components/interfaces/line cards with 10/40/100Gbps 
         or even 400Gbps throughput and nodes with a combined throughput of greater than
         10Tbps. This cannot be represented in a field which is only 32-bit long. 
-        Because a 32-bit field can only represent a max throughput of 4Gbps (2 ^ 32 BPS).
+        A 32-bit field can only represent a max throughput of 4Gbps (2 ^ 32 BPS).
         To address this, we define another format, a wider, 64-bit Sub-Object
         format.
       </t>

--- a/draft-pignataro-eimpact-icmp.xml
+++ b/draft-pignataro-eimpact-icmp.xml
@@ -819,7 +819,7 @@ Trace complete.
           <c>Node Power Draw</c>
           <c>This document</c>
           <c>2</c>
-          <c>Node Throughput</c>
+          <c>Node Throughput Short</c>
           <c>This document</c>
           <c>3</c>
           <c>Node Throughput Wide</c>


### PR DESCRIPTION
What's new:

- Added a new 64-bit "wide" Sub-Object format for Node and Component Throughput.
- Added a new section "Sub-Object Formats" to discuss the "whys" and "whens related to the new wide format
- Added some example to show how these two formats can work

(closes #35)
Please review it and suggest changes if there's room for improvement.