### PR TITLE
Updating the Limitations section

### DIFF
--- a/draft-pignataro-icmp-enviro-info.txt
+++ b/draft-pignataro-icmp-enviro-info.txt
@@ -308,7 +308,9 @@ Internet-Draft         ICMP Enviro Info Extensions             July 2026
 
    A single ICMP message can contain zero, one, or multiple instances of
    Environmental Information Objects.  The C-Type further identifies the
-   information fields carried.
+   information fields carried.  The Environmental Information Object can
+   be appended to any existing ICMP Extension Objects, subject to the
+   limitations discussed in Section 10.
 
    A single instance of the Environmental Information Object can convey
    one of the information elements defined in Section 5.2 from each
@@ -329,14 +331,14 @@ Internet-Draft         ICMP Enviro Info Extensions             July 2026
    ~                        Object payload                         ~
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+...
 
-         Figure 1: ICMP Environmental Information Extension Format
-
 
 
 Pignataro, et al.        Expires 20 January 2027                [Page 6]
 
 Internet-Draft         ICMP Enviro Info Extensions             July 2026
 
+
+         Figure 1: ICMP Environmental Information Extension Format
 
    (1) ICMP Extension Header
 
@@ -381,11 +383,9 @@ Internet-Draft         ICMP Enviro Info Extensions             July 2026
    The ICMP Environmental Information Extension Object header has the
    following format:
 
-                        1                   2                   3
-    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |             Length            | Class-Num=TBA | C-Type=1-255  |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+
 
 
 
@@ -393,6 +393,12 @@ Pignataro, et al.        Expires 20 January 2027                [Page 7]
 
 Internet-Draft         ICMP Enviro Info Extensions             July 2026
 
+
+                        1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |             Length            | Class-Num=TBA | C-Type=1-255  |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
         Figure 2: Environmental Information Extension Object Header
 
@@ -436,12 +442,6 @@ Internet-Draft         ICMP Enviro Info Extensions             July 2026
 
        A Class-Num of TBA and a C-Type of 2 are specified.
 
-       The Length is 12 if the object contains this payload.  A Length
-       value of 4 indicates that it is unavailable.
-
-
-
-
 
 
 
@@ -449,6 +449,9 @@ Pignataro, et al.        Expires 20 January 2027                [Page 8]
 
 Internet-Draft         ICMP Enviro Info Extensions             July 2026
 
+
+       The Length is 12 if the object contains this payload.  A Length
+       value of 4 indicates that it is unavailable.
 
        The returned value is the node-level present throughput, which is
        a magnitude that may be directly displayed, and is expressed in
@@ -489,9 +492,6 @@ Internet-Draft         ICMP Enviro Info Extensions             July 2026
        was issued, or 0 to indicate "unknown" or "not specified".
 
    4.  Component-level Power Draw Sub-Object
-
-
-
 
 
 
@@ -821,19 +821,19 @@ Internet-Draft         ICMP Enviro Info Extensions             July 2026
 
    Section 7 of [RFC4884] defines the ICMP Extension Structure.  As per
    RFC 4884, the Extension Structure contains exactly one Extension
-   Header followed by one or more objects.  When applied to the ICMP
-   Extended Echo Request message, the ICMP Extension Structure MUST
-   contain exactly one instance of the Interface Identification Object
-   (Section 2.1 of [RFC8335]).  So, due to the limitation of not being
-   able to append more than one extension object to an Extended Echo,
-   the extension objects defined herein cannot be appended to an
-   Extended Echo Message.
+   Header followed by one or more objects.
+
+   The extension structure defined in this draft, the Environmental
+   Information Object, cannot be appended after the ICMP Extended Echo
+   Request message, for the PROBE application, as discussed in the
+   Section 2 of [I-D.ietf-intarea-rfc8335bis].
 
 11.  IANA Considerations
 
    IANA is requested to assign the following object Class-num in the
    ICMP Extension Object Classes and Class Sub-types registry
    [IANA-ICMP-Extended]:
+
 
 
 
@@ -986,20 +986,20 @@ Internet-Draft         ICMP Enviro Info Extensions             July 2026
 
    [EERC-TCO] "TCO Certified", <https://tcocertified.com/>.
 
+   [I-D.ietf-intarea-rfc8335bis]
+              Fenner, B., Bonica, R. P., Thomas, R., Linkova, J.,
+              Lenart, C., and M. Boucadair, "PROBE: A Utility for
+              Probing Interfaces", Work in Progress, Internet-Draft,
+              draft-ietf-intarea-rfc8335bis-04, 17 April 2026,
+              <https://datatracker.ietf.org/doc/html/draft-ietf-intarea-
+              rfc8335bis-04>.
+
    [I-D.wkumari-intarea-safe-limited-domains]
               Kumari, W. A., Alston, A., Vyncke, E., and S. Krishnan,
               "Safe(r) Limited Domains", Work in Progress, Internet-
               Draft, draft-wkumari-intarea-safe-limited-domains-00, 19
               January 2024, <https://datatracker.ietf.org/doc/html/
               draft-wkumari-intarea-safe-limited-domains-00>.
-
-   [IAB-EIMPACTWS]
-              "IAB workshop on Environmental Impact of Internet
-              Applications and Systems (eimpactws)", December 2022,
-              <https://datatracker.ietf.org/group/eimpactws/>.
-
-
-
 
 
 
@@ -1009,6 +1009,11 @@ Pignataro, et al.        Expires 20 January 2027               [Page 18]
 
 Internet-Draft         ICMP Enviro Info Extensions             July 2026
 
+
+   [IAB-EIMPACTWS]
+              "IAB workshop on Environmental Impact of Internet
+              Applications and Systems (eimpactws)", December 2022,
+              <https://datatracker.ietf.org/group/eimpactws/>.
 
    [IAB-EIMPACTWS-Minutes]
               "Minutes for the IAB E-Impact Workshop Session 4: Next
@@ -1053,17 +1058,18 @@ Internet-Draft         ICMP Enviro Info Extensions             July 2026
 
 Authors' Addresses
 
-   Carlos Pignataro
-   North Carolina State University
-   United States of America
-   Email: cpignata@gmail.com, cmpignat@ncsu.edu
-
 
 
 
 Pignataro, et al.        Expires 20 January 2027               [Page 19]
 
 Internet-Draft         ICMP Enviro Info Extensions             July 2026
+
+
+   Carlos Pignataro
+   North Carolina State University
+   United States of America
+   Email: cpignata@gmail.com, cmpignat@ncsu.edu
 
 
    Jainam Parikh
@@ -1084,12 +1090,6 @@ Internet-Draft         ICMP Enviro Info Extensions             July 2026
    University of Oslo
    Norway
    Email: michawe@ifi.uio.no
-
-
-
-
-
-
 
 
 

--- a/draft-pignataro-icmp-enviro-info.txt
+++ b/draft-pignataro-icmp-enviro-info.txt
@@ -732,8 +732,9 @@ Internet-Draft         ICMP Enviro Info Extensions             July 2026
 
        *  Receiver (receiver.py) — waits for incoming data.  Requires
           two arguments: (0 or 1)
-          --probeFlag: Tells the receiver to include the Interface
-          Identification Object [RFC8335] in the response or not
+          --interfaceIdentifyFlag: Tells the receiver to include the
+          Interface Identification Object [RFC8335] in the response or
+          not
           --greenFlag: Tells the receiver to include the Environmental
           Information Object (this document) in the response or not
 
@@ -777,7 +778,6 @@ Internet-Draft         ICMP Enviro Info Extensions             July 2026
    transportation of the environmental information to a single
    administrative domain (AD).  But, based on [RFC8799], limiting a
    protocol's functionality doesn't mean that it will be secure.  So,
-   this particular document, which defines "a modified ICMP message with
 
 
 
@@ -786,6 +786,7 @@ Pignataro, et al.        Expires 20 January 2027               [Page 14]
 Internet-Draft         ICMP Enviro Info Extensions             July 2026
 
 
+   this particular document, which defines "a modified ICMP message with
    environmental information", can be classified as a FAIL-OPEN protocol
    [I-D.wkumari-intarea-safe-limited-domains].  That is, the interfaces
    of administrative domain border nodes, facing towards the open
@@ -833,7 +834,6 @@ Internet-Draft         ICMP Enviro Info Extensions             July 2026
    IANA is requested to assign the following object Class-num in the
    ICMP Extension Object Classes and Class Sub-types registry
    [IANA-ICMP-Extended]:
-
 
 
 

--- a/draft-pignataro-icmp-enviro-info.xml
+++ b/draft-pignataro-icmp-enviro-info.xml
@@ -718,7 +718,7 @@ Trace complete.
             <ul>
               <li>
                 Receiver (receiver.py) — waits for incoming data. Requires two arguments: (0 or 1) <br />
-                --probeFlag: Tells the receiver to include the Interface Identification Object <xref target="RFC8335" /> in the response or not <br />
+                --interfaceIdentifyFlag: Tells the receiver to include the Interface Identification Object <xref target="RFC8335" /> in the response or not <br />
                 --greenFlag: Tells the receiver to include the Environmental Information Object (this document) in the response or not
               </li>
               <li>

--- a/draft-pignataro-icmp-enviro-info.xml
+++ b/draft-pignataro-icmp-enviro-info.xml
@@ -14,6 +14,7 @@
 <!ENTITY RFC.4122 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4122.xml">
 <!ENTITY RFC.9547 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.9547.xml">
 <!ENTITY I-D.wkumari-intarea-safe-limited-domains SYSTEM "https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.draft-wkumari-intarea-safe-limited-domains-00.xml">
+<!ENTITY I-D.ietf-intarea-rfc8335bis SYSTEM "https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.draft-ietf-intarea-rfc8335bis-04.xml">
 ]>
 <?rfc toc="yes"?>
 <?rfc rfcedstyle="yes"?>
@@ -301,17 +302,18 @@
         considerations.
       </t>
       <t>
-        These extensions are preceded by an
-        ICMP Extension Structure Header, and include an ICMP Object Header. 
-        Both are defined in <xref target="RFC4884" />. The same backward 
-        compatibility issues that apply to <xref target="RFC4884" /> apply 
-        to this extension.
+        These extensions are preceded by an ICMP Extension Structure Header,
+        and include an ICMP Object Header. Both are defined in <xref target="RFC4884" />.
+        The same backward compatibility issues that apply to <xref target="RFC4884" />
+        apply to this extension.
       </t>
 
       <t>
         A single ICMP message can contain zero, one, or multiple instances of 
         Environmental Information Objects.  The C-Type further identifies the 
-        information fields carried.
+        information fields carried. The Environmental Information Object can
+        be appended to any existing ICMP Extension Objects, subject to the limitations
+        discussed in <xref target="limitations" />.
       </t>
       <t>
         A single instance of the Environmental Information Object can convey 
@@ -805,20 +807,20 @@ Trace complete.
       </t>
     </section>
 
-    <section title="Limitations">
+    <section title="Limitations" anchor="limitations">
       <t>
         Section 7 of <xref target="RFC4884" /> defines the ICMP Extension Structure.
         As per RFC 4884, the Extension Structure contains exactly one Extension
-        Header followed by one or more objects.  When applied to the ICMP Extended
-        Echo Request message, the ICMP Extension Structure MUST contain exactly
-        one instance of the Interface Identification Object (Section 2.1 of
-        <xref target="RFC8335" />). So, due to the limitation of not being able to
-        append more than one extension object to an Extended Echo, the extension
-        objects defined herein cannot be appended to an Extended Echo Message.
+        Header followed by one or more objects.
+      </t>
+      <t>
+        The extension structure defined in this draft, the Environmental Information
+        Object, cannot be appended after the ICMP Extended Echo Request message,
+        for the PROBE application, as discussed in the Section 2 of <xref target="I-D.ietf-intarea-rfc8335bis" />.
       </t>
     </section>
 
-    <section title="IANA Considerations">
+    <section title="IANA Considerations" anchor="iana-considerations">
       <t>
         IANA is requested to assign the following object Class-num in the ICMP 
         Extension Object Classes and Class Sub-types registry 
@@ -947,6 +949,7 @@ Trace complete.
       &RFC.8799;
       &RFC.9547;
       &I-D.wkumari-intarea-safe-limited-domains;
+      &I-D.ietf-intarea-rfc8335bis;
 
       <reference anchor="IAB-EIMPACTWS" target="https://datatracker.ietf.org/group/eimpactws/">
         <front>


### PR DESCRIPTION
The current limitation section is based on the RFC8335. Which indirectly states that no new Extension Objects can be appended to the Extended Echo.
```
RFC8335:

Section 7 of [RFC4884] defines the ICMP Extension Structure.  As per
   RFC 4884, the Extension Structure contains exactly one Extension
   Header followed by one or more objects.  When applied to the ICMP
   Extended Echo Request message, the ICMP Extension Structure MUST
   contain exactly one instance of the Interface Identification Object
   (see [Section 2.1]).
```
And this is what our draft refers to.

But, since the start of this PR, there have been a lot of discussions over at https://datatracker.ietf.org/doc/draft-ietf-intarea-rfc8335bis/04/ and this behavior has changed a bit.
```
RFC8335-bis

Section 7 of [RFC4884] defines the ICMP Extension Structure.  As per
   RFC 4884, the Extension Structure contains exactly one Extension
   Header followed by one or more objects.  When applied to the ICMP
   Extended Echo Request message, the Extension Object(s) define the
   operation to perform.  In the PROBE application, the ICMP Extension
   Structure MUST contain exactly one instance of the Interface
   Identification Object (Section 2.1), and the ICMP Extension Structure
   does not cover the rest of the packet; it ends at the end of the
   single Interface Identification Object, and what follows is simply
   optional data.  The behavior when it contains a different Extension
   Object is not defined by this memo.
   [I-D.ietf-6man-icmpv6-reflection] is an example of a document which
   defines a different Extension Object and the corresponding behavior.
```
And, William's and my PoC appends our Enviro Info Object to the Extended Echo Req (which is legal, as per rfc8335-bis)

And so, updated the Limitations section based on the new rfc8335-bis draft